### PR TITLE
Revert "Lower PHP version requirement ^8.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 Monolog Handler for sending messages to Microsoft Teams channels using Workflow / Power Automate. I put this together based on [monolog-microsoft-teams](https://github.com/cmdisp/monolog-microsoft-teams) after Microsoft retired Office 365 connectors.
 
-This is a fork of the original paulgsepulveda/monolog-teams-workflow repository making it available for PHP version 8.1
-
 ## Install
 
 ```bash
-$ composer require Metamorfer/monolog-teams-workflow
+$ composer require paulgsepulveda/monolog-teams-workflow
 ```
 
 ## Configuring Workflow
@@ -22,7 +20,7 @@ $ composer require Metamorfer/monolog-teams-workflow
 
 ```php
 $logger = new \Monolog\Logger('app');
-$logger->pushHandler(new \Metamorfer\MonologTeamsWorkflow\TeamsWorkflowLogHandler('INCOMING_WEBHOOK_URL', \Monolog\Level::Error));
+$logger->pushHandler(new \Paulgsepulveda\MonologTeamsWorkflow\TeamsWorkflowLogHandler('INCOMING_WEBHOOK_URL', \Monolog\Level::Error));
 
 $logger->error('Error message');
 ```
@@ -36,7 +34,7 @@ Create a [custom channel](https://laravel.com/docs/master/logging#creating-custo
 ```php
 'teams' => [
     'driver' => 'custom',
-    'via' => \Metamorfer\MonologTeamsWorkflow\TeamsLogChannel::class,
+    'via' => \Paulgsepulveda\MonologTeamsWorkflow\TeamsLogChannel::class,
     'level' => 'error',
     'url' => 'INCOMING_WEBHOOK_URL',
     'source_name' => env('APP_NAME'),

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "metamorfer/monolog-teams-workflow",
+    "name": "paulgsepulveda/monolog-teams-workflow",
     "description": "Monolog Handler for sending messages to Microsoft Teams channels using the Workflow webhook",
     "type": "library",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
         "ext-curl": "*",
         "monolog/monolog": "^3.3.1"
@@ -11,12 +11,12 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Metamorfer\\MonologTeamsWorkflow\\": "src/"
+            "Paulgsepulveda\\MonologTeamsWorkflow\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Metamorfer\\MonologTeamsWorkflow\\Tests\\": "tests/"
+            "Paulgsepulveda\\MonologTeamsWorkflow\\Tests\\": "tests/"
         }
     },
 

--- a/src/TeamsFormatter.php
+++ b/src/TeamsFormatter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Metamorfer\MonologTeamsWorkflow;
+namespace Paulgsepulveda\MonologTeamsWorkflow;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Level;

--- a/src/TeamsLogChannel.php
+++ b/src/TeamsLogChannel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Metamorfer\MonologTeamsWorkflow;
+namespace Paulgsepulveda\MonologTeamsWorkflow;
 
 use Monolog\Level;
 use Monolog\Logger;

--- a/src/TeamsWorkflowLogHandler.php
+++ b/src/TeamsWorkflowLogHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Metamorfer\MonologTeamsWorkflow;
+namespace Paulgsepulveda\MonologTeamsWorkflow;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;

--- a/tests/TeamsFormatterTest.php
+++ b/tests/TeamsFormatterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Metamorfer\MonologTeamsWorkflow\Tests;
+namespace Paulgsepulveda\MonologTeamsWorkflow\Tests;
 
-use Metamorfer\MonologTeamsWorkflow\TeamsFormatter;
+use Paulgsepulveda\MonologTeamsWorkflow\TeamsFormatter;
 use Monolog\Formatter\FormatterInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/TeamsWorkflowLogHandlerTest.php
+++ b/tests/TeamsWorkflowLogHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace Metamorfer\MonologTeamsWorkflow\Tests;
+namespace Paulgsepulveda\MonologTeamsWorkflow\Tests;
 
-use Metamorfer\MonologTeamsWorkflow\TeamsWorkflowLogHandler;
+use Paulgsepulveda\MonologTeamsWorkflow\TeamsWorkflowLogHandler;
 use PHPUnit\Framework\TestCase;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;


### PR DESCRIPTION
Reverts paulgsepulveda/monolog-teams-workflow#2 
I don't think that you have to take those changes at all. I was playing with it just for our use case because of legacy dependencies.
Excuse me if I misled you.